### PR TITLE
Support to spritesheets without atlas and adjustable frames.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ To make part of text **BOLD** include it like this:
 	<li><strong>hideModal</strong> | The function to hide a previously created and shown modal, takes the modal name/type as an argument</li>
 	<li><strong>getModalItem</strong> | The function to get an element from a previously created modal, takes the modal name/type and the position of the element (index) as an argument</li>
 	<li><strong>destroyModal</strong> | Remove a previously created modal from the registry</li>
-	<li><strong>updateModalValue</strong> | Dynamically change the value of an element inside a modal, takes the modal name/type, the changed value, and the index of the element as arguments (experimental function)</li>
+	<li><strong>updateModalValue</strong> | Dynamically change the value of an element inside a modal,takes respectively: the new value, the modal name/type, and the index of the element as arguments (experimental function)</li>
 </ul>
 
 <hr>

--- a/src/modal.js
+++ b/src/modal.js
@@ -184,10 +184,10 @@ gameModal = function(game) {
                         modalLabel = game.add.sprite(0, 0, atlasParent, content);
                     }else{
                         modalLabel = game.add.sprite(0,0,content);
+                        modalLabel.frame = imageFrame;
                     }
                     modalLabel.scale.setTo(contentScale, contentScale);
                     modalLabel.contentType = 'sprite';
-                    modalLabel.frame = imageFrame;
                     modalLabel.x = (centerX - ((modalLabel.width) / 2)) + offsetX;
                     modalLabel.y = (centerY - ((modalLabel.height) / 2)) + offsetY;
                 } else if (itemType === "button") {

--- a/src/modal.js
+++ b/src/modal.js
@@ -1,8 +1,6 @@
 var gameModal = gameModal || {};
 
-
 gameModal = function(game) {
-
     var _this = this;
     game.modals = {};
 
@@ -98,7 +96,7 @@ gameModal = function(game) {
                 var centerY = game.height / 2;
                 var callback = item.callback || false;
                 var textAlign = item.textAlign || "left";
-                var atlasParent = item.atlasParent || "";
+                var atlasParent = item.atlasParent || null;
                 var buttonHover = item.buttonHover || content;
                 var buttonActive = item.buttonActive || content;
                 var graphicColor = item.graphicColor || 0xffffff;
@@ -181,9 +179,15 @@ gameModal = function(game) {
                     modalLabel.angle = itemAngle;
                     modalLabel.contentType = 'tileSprite';
                 } else if (itemType === "sprite") {
-                    modalLabel = game.add.sprite(0, 0, atlasParent, content);
+
+                    if(atlasParent){
+                        modalLabel = game.add.sprite(0, 0, atlasParent, content);
+                    }else{
+                        modalLabel = game.add.sprite(0,0,content);
+                    }
                     modalLabel.scale.setTo(contentScale, contentScale);
                     modalLabel.contentType = 'sprite';
+                    modalLabel.frame = imageFrame;
                     modalLabel.x = (centerX - ((modalLabel.width) / 2)) + offsetX;
                     modalLabel.y = (centerY - ((modalLabel.height) / 2)) + offsetY;
                 } else if (itemType === "button") {
@@ -264,6 +268,10 @@ gameModal = function(game) {
                 }
             } else if (item.contentType === "image") {
                 item.loadTexture(value);
+            }
+            
+             else if (item.contentType === "sprite") {
+                item.frame = value;
             }
 
         },


### PR DESCRIPTION
- Default atlasParent now is null (this wasnt fully necessary, but sometimes a blank string in a boolean test  make bugs), to then test if it was specified. If not specified, it just call the sprite without the atlasParent. 

- The sprite now uses the frame option to call the respective spritesheet frame(with a normal index/number).
 
- Readme.md updated on updateModalValue function, the order was wrong i guess, and i for example need to create an issue to understood it.

In my tests everything went fine without any bugs.

note: this is my first pull in github, i hope you did it the right way.